### PR TITLE
(deadlock issue): Moving conversions to codec to stop the 2s timeout

### DIFF
--- a/zamp_public_workflow_sdk/temporal/codec/large_payload_codec.py
+++ b/zamp_public_workflow_sdk/temporal/codec/large_payload_codec.py
@@ -6,6 +6,15 @@ import json
 from zamp_public_workflow_sdk.temporal.codec.models import BucketData
 from zamp_public_workflow_sdk.temporal.codec.storage_client import StorageClient
 
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.transformer import Transformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.collections.list_transformer import ListTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.bytes_transformer import BytesTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.bytesio_transformer import BytesIOTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.pydantic_model_metaclass_transformer import PydanticModelMetaclassTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.pydantic_type_transformer import PydanticTypeTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.collections.tuple_transformer import TupleTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.datetime_transformer import DateTransformer
+
 PAYLOAD_SIZE_THRESHOLD = 2 * 1024 * 1024
 CODEC_BUCKET_ENCODING = "codec_bucket"
 CODEC_SENSITIVE_METADATA_KEY = "codec"
@@ -15,9 +24,19 @@ class LargePayloadCodec(PayloadCodec):
     def __init__(self, storage_client: StorageClient):
         self.storage_client = storage_client
 
+        Transformer.register_transformer(PydanticTypeTransformer())
+        Transformer.register_transformer(PydanticModelMetaclassTransformer())
+        Transformer.register_transformer(BytesTransformer())
+        Transformer.register_transformer(BytesIOTransformer())
+        Transformer.register_transformer(DateTransformer())
+
+        Transformer.register_collection_transformer(TupleTransformer())
+        Transformer.register_collection_transformer(ListTransformer())
+
     async def encode(self, payload: Iterable[Payload]) -> List[Payload]:
         encoded_payloads = []
         for p in payload:
+            p.data = json.dumps(p.data, separators=(",", ":"), sort_keys=True, default=lambda x: Transformer.serialize(x).serialized_value).encode()
             if p.ByteSize() > PAYLOAD_SIZE_THRESHOLD or p.metadata.get(CODEC_SENSITIVE_METADATA_KEY, "None".encode()) == CODEC_SENSITIVE_METADATA_VALUE.encode():
                 blob_name = f"{uuid4()}"
                 await self.storage_client.upload_file(blob_name, p.data)

--- a/zamp_public_workflow_sdk/temporal/codec/payload_codec_converter.py
+++ b/zamp_public_workflow_sdk/temporal/codec/payload_codec_converter.py
@@ -1,0 +1,37 @@
+from typing import Sequence, List, Any, Optional
+from temporalio.api.common.v1 import Payload
+from typing import Type
+
+from zamp_public_workflow_sdk.temporal.data_converters.pydantic_payload_converter import PydanticPayloadConverter
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.transformer import Transformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.pydantic_model_metaclass_transformer import PydanticModelMetaclassTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.pydantic_type_transformer import PydanticTypeTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.bytes_transformer import BytesTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.bytesio_transformer import BytesIOTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.datetime_transformer import DateTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.collections.tuple_transformer import TupleTransformer
+from zamp_public_workflow_sdk.temporal.data_converters.transformers.collections.list_transformer import ListTransformer
+
+
+class PayloadCodecConverter:
+    def __init__(self):
+        pass
+
+    def decode_type_hints(self, payloads: Sequence[Payload], type_hints: Optional[List[Type]] = None) -> List[Any]:
+        return None
+    
+class PydanticPayloadCodecConverter(PayloadCodecConverter):
+    def __init__(self):
+        super().__init__()
+        Transformer.register_transformer(PydanticTypeTransformer())
+        Transformer.register_transformer(PydanticModelMetaclassTransformer())
+        Transformer.register_transformer(BytesTransformer())
+        Transformer.register_transformer(BytesIOTransformer())
+        Transformer.register_transformer(DateTransformer())
+
+        Transformer.register_collection_transformer(TupleTransformer())
+        Transformer.register_collection_transformer(ListTransformer())
+
+    def decode_type_hints(self, payloads: Sequence[Payload], type_hints: Optional[List[Type]] = None) -> List[Any]:
+        
+        

--- a/zamp_public_workflow_sdk/temporal/data_converters/base.py
+++ b/zamp_public_workflow_sdk/temporal/data_converters/base.py
@@ -1,9 +1,34 @@
 from temporalio.converter import DataConverter, PayloadCodec, PayloadConverter, CompositePayloadConverter
 import dataclasses
 from typing import Type
+from temporalio.api.common.v1 import Payload
+from typing import Sequence, List, Any, Optional
+import temporalio.api.common.v1
+from zamp_public_workflow_sdk.temporal.codec.payload_codec_converter import PayloadCodecConverter, PydanticPayloadCodecConverter
+
+class PydanticCodecDataConverter(DataConverter):
+    def __init__(self):
+        super().__init__()
+        self.pydantic_codec_converter: PayloadCodecConverter = PydanticPayloadCodecConverter()
+
+    async def decode(
+        self,
+        payloads: Sequence[temporalio.api.common.v1.Payload],
+        type_hints: Optional[List[Type]] = None,
+    ) -> List[Any]:
+        
+        if self.pydantic_codec_converter :
+            payloads = await self.pydantic_codec_converter.decode_type_hints(payloads, type_hints)
+
+        return super().decode(payloads, type_hints)
+
+    @staticmethod
+    def default() -> 'PydanticCodecDataConverter':
+        return PydanticCodecDataConverter()
 
 class BaseDataConverter:
-    converter = DataConverter.default
+    def __init__(self, converter: DataConverter = DataConverter.default):
+        self.converter = converter
 
     def replace_payload_codec(self, payload_codec: PayloadCodec) -> 'BaseDataConverter':
         self.converter = dataclasses.replace(self.converter, payload_codec=payload_codec)


### PR DESCRIPTION
Temporal python's SDK has a differentiation between payload codec and the payload converter.

The codec runs outside the sandbox. 

Sandbox has a 2s deadlock detection. 

Moving the pydantic conversion to the codec to remove deadlock detection.